### PR TITLE
feat: add python testing surface for CLI/API/module testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BDD E2E Orchestrator
 
-Automated BDD end-to-end testing with two Claude Code agents: Writer creates Gherkin feature files + Playwright step definitions, Executor runs them against a staging URL. A local AI orchestrator routes tasks and manages git merges.
+Automated BDD testing with two Claude Code agents: Writer creates Gherkin feature files + step definitions, Executor runs them. Supports two testing surfaces: **browser** (Playwright + Cucumber) for web UI testing, and **python** (pytest-bdd) for CLI, API, and module testing. A local AI orchestrator routes tasks and manages git merges.
 
 ## Architecture
 
@@ -28,11 +28,11 @@ Automated BDD end-to-end testing with two Claude Code agents: Writer creates Ghe
 
 ### BDD Cycle (per task)
 
-1. Orchestrator assigns a page to Writer
-2. **Writer** creates `.feature` file + step definitions + Page Objects
-3. Writer validates with `npx cucumber-js --dry-run`, commits, calls `send_to_executor`
+1. Orchestrator assigns a task to Writer
+2. **Writer** creates `.feature` file + step definitions (+ Page Objects for browser surface)
+3. Writer validates (`npx cucumber-js --dry-run` or `pytest --collect-only`), commits, calls `send_to_executor`
 4. Orchestrator merges `writer/<task>` into Executor's worktree
-5. **Executor** runs `npx cucumber-js` against the staging URL
+5. **Executor** runs tests (`npx cucumber-js` for browser, `pytest` for python)
 6. Executor reports pass/fail via `send_executor_results`
 7. **Pass**: Orchestrator merges `executor/<task>` into main, advances to next task
 8. **Fail**: Orchestrator routes failure details back to Writer for fixes (up to 5 retries)
@@ -49,6 +49,15 @@ IDLE -> WAITING_WRITER -> WAITING_EXECUTOR -> IDLE (next task)
 ```
 main -> writer/<task> -> merge into executor -> executor/<task> -> merge into main
 ```
+
+## Testing Surfaces
+
+| Surface | Framework | Language | Use Case |
+|---------|-----------|----------|----------|
+| `browser` (default) | Playwright + Cucumber | TypeScript | Web UI E2E testing |
+| `python` | pytest-bdd | Python | CLI, API, module, agent testing |
+
+The wizard asks which surface to use. Browser projects get `e2e/` with Playwright scaffolding. Python projects get `tests/` with pytest-bdd scaffolding. The orchestrator automatically adapts instructions and test commands to the selected surface.
 
 ## Two Modes
 
@@ -99,6 +108,7 @@ tmux:
   session_name: my-app
 
 repo_dir: ~/Repositories/my-app
+testing_surface: "browser"  # "browser" (Playwright+Cucumber) or "python" (pytest-bdd)
 
 ui:
   base_url: https://staging.example.com
@@ -114,6 +124,7 @@ env_setup:
   teardown_command: ""
 
 features_mode: "new"  # "new" (write features from scratch) or "existing" (reuse .feature files)
+# test_command: "pytest tests/ -v --tb=short"  # python surface only
 
 agents:
   writer:

--- a/docs/BDD PROMPTS.md
+++ b/docs/BDD PROMPTS.md
@@ -102,6 +102,101 @@ e2e/
 7. Run `npx cucumber-js --dry-run` to verify all steps are wired up
 8. Commit and hand off to Executor
 
+## FILE_TARGET: writer_agent_python/CLAUDE.md
+
+You are a **BDD Writer** agent. Your job is to create pytest-bdd step definitions for Python/CLI/API testing using Gherkin `.feature` files.
+
+### Stack
+- **Gherkin** for feature files (Given/When/Then scenarios)
+- **pytest-bdd** for step definitions (Python)
+- **subprocess** for CLI/bash testing
+- **httpx** for API testing
+- Direct imports for Python module testing
+
+### Directory Structure
+```
+tests/
+├── features/        # .feature files (Gherkin)
+├── step_defs/       # Step definitions (Python)
+└── conftest.py      # Fixtures and scenario discovery
+```
+
+### Guidelines
+- Write clear, business-readable Gherkin scenarios
+- Use `@given`, `@when`, `@then` decorators from pytest-bdd
+- For CLI testing: use `subprocess.run()` with `capture_output=True`
+- For module testing: import the module directly
+- For API testing: use `httpx` client
+- Include `@smoke`, `@regression`, or `@wip` markers as appropriate
+- Validate with `pytest --collect-only` before handoff
+
+### For Each Task
+1. Create the `.feature` file in `tests/features/`
+2. Create step definitions in `tests/step_defs/` with `@scenario` linking to the feature
+3. Add any needed fixtures in `conftest.py`
+4. Run `pytest --collect-only` to verify all steps are wired up
+5. Commit and hand off to Executor
+
+## FILE_TARGET: writer_agent_python_existing/CLAUDE.md
+
+You are a **BDD Writer** agent. Your job is to implement pytest-bdd step definitions for **existing** Gherkin `.feature` files that test Python modules, CLI tools, or APIs.
+
+### Stack
+- **pytest-bdd** for step definitions (Python)
+- **subprocess** for CLI/bash testing
+- **httpx** for API testing
+- Direct imports for Python module testing
+
+### Directory Structure
+```
+tests/
+├── features/        # EXISTING .feature files (DO NOT MODIFY)
+├── step_defs/       # Step definitions (Python) -- YOU CREATE THESE
+└── conftest.py      # Fixtures and scenario discovery
+```
+
+### Guidelines
+- **DO NOT modify existing .feature files** -- they are the spec
+- Read each .feature file carefully to understand all Given/When/Then steps
+- Use `@given`, `@when`, `@then` decorators from pytest-bdd
+- For CLI testing: use `subprocess.run()` with `capture_output=True`
+- For module testing: import the module directly
+- For API testing: use `httpx` client
+- Validate with `pytest --collect-only` before handoff
+
+### For Each Task
+1. **Read the .feature file** assigned in the task
+2. Catalog every unique step (Given/When/Then)
+3. Create step definitions in `tests/step_defs/` matching ALL steps in the feature
+4. Add any needed fixtures in `conftest.py`
+5. Run `pytest --collect-only` to verify all steps are wired up
+6. Commit and hand off to Executor
+
+## FILE_TARGET: executor_agent_python/CLAUDE.md
+
+You are a **BDD Executor** agent. Your job is to run pytest-bdd tests and report detailed results.
+
+### Execution
+- Run tests: `pytest tests/ -v --tb=short`
+- Capture full output for failure analysis
+
+### Reporting
+For each test run, report:
+- Total scenarios passed / failed
+- For failures: step name, error message, traceback
+- Distinguish between test bugs (bad step defs) and application bugs (code under test)
+
+### Environment Setup/Teardown
+- Run `bash e2e/support/env-setup.sh` BEFORE tests (if it exists)
+- Run `bash e2e/support/env-teardown.sh` AFTER tests (regardless of pass/fail)
+- If setup fails, report failure immediately -- do not run tests
+
+### Guidelines
+- Do NOT modify feature files or step definitions -- only run them
+- If tests fail due to **test code bugs** (wrong imports, bad assertions, missing steps): report back to Writer with specific fix instructions
+- If tests fail due to **application bugs**: report as application issue with reproduction steps
+- If tests pass: confirm success and report summary
+
 ## FILE_TARGET: executor_agent/CLAUDE.md
 
 You are a **BDD Executor** agent. Your job is to run Playwright+Cucumber E2E tests against a staging URL and report detailed results.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -33,14 +33,16 @@ The wizard asks you to pick a mode:
 2. **BDD E2E Testing** -- write & run Playwright+Cucumber tests against a staging URL
 
 For mode 2, an agentic wizard launches and guides you through:
-- **Staging URL** -- the base URL to test against
+- **Testing surface** -- browser (Playwright+Cucumber) or python (pytest-bdd)
+- **Staging URL** -- the base URL to test against (required for browser, optional for python)
 - **Existing features** -- auto-discovers `.feature` files and YAML page objects in the repo; offers to reuse them (generates "implement step defs" tasks) or start fresh
-- **Pages** -- which routes to test (can auto-discover from repo; skipped if reusing existing features)
-- **Test credentials** -- email/password for auth (stored in `e2e/support/test-data.yaml`)
+- **Pages** -- which routes to test (browser only; skipped if reusing existing features)
+- **Project root / test command** -- path and test runner command (python surface only)
+- **Test credentials** -- email/password for auth (browser: stored in `e2e/support/test-data.yaml`)
 - **Environment setup/teardown** -- commands to run before/after tests
 - **PRD import** -- optionally read a PRD to extract pages and acceptance criteria
 
-The wizard creates worktrees, config, tasks, Playwright+Cucumber scaffolding (`e2e/` directory, `cucumber.js`, `tsconfig.json`), test data files, and agent `CLAUDE.md` files.
+The wizard creates worktrees, config, tasks, framework scaffolding (browser: `e2e/` + Playwright+Cucumber; python: `tests/` + pytest-bdd), and agent `CLAUDE.md` files.
 
 ## 4. Customize
 

--- a/docs/wizard_agent.md
+++ b/docs/wizard_agent.md
@@ -5,8 +5,15 @@ with the user to collect everything needed to set up BDD E2E testing for their p
 
 ### What You Need to Collect
 
-1. **Staging URL** (required) -- the base URL to test against
-2. **Pages to test** (required) -- which pages/routes to generate tasks for
+1. **Testing surface** (required, ask first) -- what kind of project is this?
+   - `"browser"` -- web app with a UI (Playwright + Cucumber, TypeScript)
+   - `"python"` -- CLI, API, Python module, or agent testing (pytest-bdd, Python)
+   Ask early: "Is this a browser/web app, or a CLI/API/Python project?"
+   Default to `"browser"` if unclear.
+
+2. **Staging URL** (required for browser, optional for python) -- the base URL to test against
+   - For `python` surface: only needed if the project has an API to test
+3. **Pages to test** (required for browser, skip for python) -- which pages/routes to generate tasks for
    - Ask the user, or inspect the repo for route files if available
    - For each page, ask what to focus testing on
 
@@ -22,19 +29,24 @@ with the user to collect everything needed to set up BDD E2E testing for their p
    - Use them as the page/task list (one task per .feature file)
    - Skip the "pages to test" question
    - YAML page objects become selector references for the Writer agent
-3. **Test credentials** (recommended) -- email/password for a test user
+3. **Project root** (required for python surface) -- path to the project being tested
+   - Ask: "What's the project root directory?" (e.g., `~/Repositories/my-project`)
+   - Ask: "What command runs the project's tests?" (e.g., `pytest tests/ -v`)
+4. **Test credentials** (recommended) -- email/password for a test user
    - Almost all E2E tests need authentication
    - Use read -s pattern for passwords in the output (mask in conversation)
-4. **Per-page test data** (optional) -- form values, search terms, specific inputs
-5. **Environment setup command** (optional) -- command to run before tests
+5. **Per-page test data** (optional, browser only) -- form values, search terms, specific inputs
+6. **Environment setup command** (optional) -- command to run before tests
    - Examples: reset test accounts, clear DB, seed data, call an API
-6. **Environment teardown command** (optional) -- command to run after tests
-7. **PRD file** (optional) -- if the user has a PRD, read it to extract pages and acceptance criteria
+7. **Environment teardown command** (optional) -- command to run after tests
+8. **PRD file** (optional) -- if the user has a PRD, read it to extract pages and acceptance criteria
 
 ### Conversation Guidelines
 
 - Be concise. Ask one topic at a time.
-- If the repo has route files (e.g., Next.js `app/` or `pages/`, React Router, Express routes),
+- Ask about testing surface FIRST -- it determines the rest of the conversation flow.
+- For `python` surface: skip page inspection, staging URL is optional, ask for project root and test command instead.
+- For `browser` surface: if the repo has route files (e.g., Next.js `app/` or `pages/`, React Router, Express routes),
   offer to discover pages automatically.
 - Suggest reasonable defaults when possible.
 - If the user provides a PRD file path, read it and extract testable pages with acceptance criteria.
@@ -46,6 +58,7 @@ When you have everything, write a file called `wizard-output.json` with this exa
 
 ```json
 {
+  "testing_surface": "browser",
   "base_url": "https://staging.example.com",
   "features_mode": "new",
   "features_dir": "",
@@ -67,6 +80,8 @@ When you have everything, write a file called `wizard-output.json` with this exa
     "setup_command": "curl -X POST https://staging.example.com/api/test/reset",
     "teardown_command": ""
   },
+  "project_root": "",
+  "test_command": "",
   "prd_path": ""
 }
 ```
@@ -85,6 +100,13 @@ When you have everything, write a file called `wizard-output.json` with this exa
   ```
 - `page_object_files`: array of paths to YAML page object files (reference material for Writer)
 - `features_dir`: relative path where .feature files live in the source repo
+
+#### Testing surface fields
+
+- `testing_surface`: `"browser"` (default) or `"python"`
+- `project_root`: path to the project being tested (python surface only)
+- `test_command`: command to run the project's tests (python surface only, e.g. `pytest tests/ -v`)
+- For `python` surface: `base_url` is optional, `pages` array can be empty (`.feature` files drive tasks)
 
 Fields can be empty strings or empty arrays if the user skipped them.
 After writing the file, tell the user you're done and the wizard will continue.

--- a/orchestrator/orchestrator.py
+++ b/orchestrator/orchestrator.py
@@ -80,6 +80,8 @@ mailbox_dir = str(root_dir / "shared" / args.project / "mailbox")
 tasks_path = project_dir / "tasks.json"
 repo_dir = config.get("repo_dir", "")
 features_mode = config.get("features_mode", "new")
+testing_surface = config.get("testing_surface", "browser")
+test_command = config.get("test_command", "pytest tests/ -v --tb=short")
 
 # --- Setup Logging ---
 logging.basicConfig(
@@ -632,7 +634,45 @@ def assign_task_to_writer(task: dict):
     global_creds = test_data.get("global", {}).get("credentials", {})
     page_test_data = test_data.get("pages", {}).get(page_url, {})
 
-    if features_mode == "existing":
+    if testing_surface == "python":
+        # --- Python surface instructions ---
+        feature_file = task.get("feature_file", "")
+        if features_mode == "existing":
+            instructions = (
+                f"Implement pytest-bdd step definitions for the existing "
+                f"feature file: {feature_file}. "
+                f"FIRST: Read the feature file to understand all scenarios and steps. "
+                "Create step definitions in tests/step_defs/ using @given, @when, @then decorators. "
+                "Use subprocess.run() for CLI testing, direct imports for modules, httpx for APIs. "
+                "Do NOT modify the existing .feature file. "
+                "Validate with: pytest --collect-only. "
+                "When ready, commit and use send_to_executor to hand off."
+            )
+        else:
+            instructions = (
+                f"Write BDD feature files and pytest-bdd step definitions. "
+            )
+            if test_focus:
+                instructions += f"Focus on testing: {test_focus}. "
+            if acceptance_criteria:
+                instructions += "Acceptance criteria:\n" + "\n".join(f"- {ac}" for ac in acceptance_criteria) + "\n"
+            instructions += (
+                "Create: (1) a .feature file in tests/features/, (2) step definitions in tests/step_defs/. "
+                "Use subprocess.run() for CLI testing, direct imports for modules, httpx for APIs. "
+                "Validate with: pytest --collect-only. "
+                "When ready, commit and use send_to_executor to hand off."
+            )
+
+        content = {
+            "task_id": task["id"],
+            "title": task["title"],
+            "description": task["description"],
+            "feature_file": feature_file,
+            "base_url": base_url,
+            "test_data": {"credentials": global_creds},
+            "instructions": instructions,
+        }
+    elif features_mode == "existing":
         feature_file = task.get("feature_file", "")
         instructions = (
             f"Implement Cucumber step definitions and Playwright Page Objects for the existing "
@@ -755,10 +795,17 @@ def handle_writer_message(message: dict):
     )
     if setup_cmd.strip():
         executor_instructions += f"BEFORE running tests, execute environment setup: {setup_cmd}. If setup fails, report failure immediately. "
-    executor_instructions += (
-        f"Run the Cucumber tests against the staging URL ({base_url}): "
-        "npx cucumber-js --format progress --format json:reports/results.json. "
-    )
+
+    if testing_surface == "python":
+        executor_instructions += (
+            f"Run the pytest-bdd tests: {test_command}. "
+        )
+    else:
+        executor_instructions += (
+            f"Run the Cucumber tests against the staging URL ({base_url}): "
+            "npx cucumber-js --format progress --format json:reports/results.json. "
+        )
+
     if teardown_cmd.strip():
         executor_instructions += f"AFTER tests (regardless of pass/fail), run teardown: {teardown_cmd}. "
     executor_instructions += "Report results using the send_executor_results MCP tool."
@@ -839,7 +886,22 @@ def handle_executor_message(message: dict):
             print(f"   Failed {task['attempts']} times. Check orchestrator.log.\n")
             log_to_report(f"**TASK STUCK: {task['id']}** -- exceeded max attempts ({task['attempts']})\n")
         else:
-            if features_mode == "existing":
+            if testing_surface == "python":
+                if features_mode == "existing":
+                    fix_instructions = (
+                        "The Executor reported test failures. Review the failure details, "
+                        "fix the step definitions or fixtures (do NOT modify the .feature file), "
+                        "then commit and use send_to_executor to hand off again."
+                    )
+                    fix_message = "Tests failed. Fix the step definitions or fixtures and re-send."
+                else:
+                    fix_instructions = (
+                        "The Executor reported test failures. Review the failure details, "
+                        "fix the issues in feature files, step definitions, or fixtures, "
+                        "then commit and use send_to_executor to hand off again."
+                    )
+                    fix_message = "Tests failed. Fix the feature files, step definitions, or fixtures and re-send."
+            elif features_mode == "existing":
                 fix_instructions = (
                     "The Executor reported test failures. Review the failure details, "
                     "fix the step definitions or Page Objects (do NOT modify the .feature file), "

--- a/scripts/new-project.sh
+++ b/scripts/new-project.sh
@@ -271,7 +271,7 @@ fi
 UI_BASE_URL=$(python3 -c "import json; d=json.load(open('$WIZARD_OUTPUT')); print(d.get('base_url',''))")
 UI_BASE_URL="${UI_BASE_URL%/}"
 
-if [[ -z "$UI_BASE_URL" ]]; then
+if [[ -z "$UI_BASE_URL" && "$TESTING_SURFACE" == "browser" ]]; then
     error "No base URL in wizard output."
     exit 1
 fi
@@ -300,6 +300,11 @@ ENV_TEARDOWN_CMD=$(python3 -c "import json; d=json.load(open('$WIZARD_OUTPUT'));
 
 # Parse PRD path
 PRD_PATH=$(python3 -c "import json; d=json.load(open('$WIZARD_OUTPUT')); print(d.get('prd_path',''))")
+
+# Parse testing surface
+TESTING_SURFACE=$(python3 -c "import json; d=json.load(open('$WIZARD_OUTPUT')); print(d.get('testing_surface','browser'))")
+TEST_COMMAND=$(python3 -c "import json; d=json.load(open('$WIZARD_OUTPUT')); print(d.get('test_command','pytest tests/ -v --tb=short'))")
+PROJECT_ROOT=$(python3 -c "import json; d=json.load(open('$WIZARD_OUTPUT')); print(d.get('project_root',''))")
 
 # Parse features mode
 FEATURES_MODE=$(python3 -c "import json; d=json.load(open('$WIZARD_OUTPUT')); print(d.get('features_mode','new'))")
@@ -331,7 +336,8 @@ if [[ "$FEATURES_MODE" != "existing" ]] && [[ ${#UI_PAGES[@]} -eq 0 ]]; then
     UI_TEST_DATA=("")
 fi
 
-info "Base URL: $UI_BASE_URL"
+info "Testing surface: $TESTING_SURFACE"
+info "Base URL: ${UI_BASE_URL:-(none)}"
 info "Features mode: $FEATURES_MODE"
 if [[ "$FEATURES_MODE" == "existing" ]]; then
     info "Found ${#FEATURE_SOURCE_PATHS[@]} existing .feature file(s)"
@@ -420,9 +426,73 @@ if [[ -f "$REPO_DIR/CLAUDE.md" ]]; then
     fi
 fi
 
-# ─── Phase 4b: Playwright+Cucumber bootstrap ─────────────────────────────────
+# ─── Phase 4b: Test framework bootstrap ──────────────────────────────────────
 echo ""
-if [[ ! -f "$REPO_DIR/playwright.config.ts" && ! -f "$REPO_DIR/cucumber.js" ]]; then
+if [[ "$TESTING_SURFACE" == "python" ]]; then
+    # --- Python / pytest-bdd bootstrap ---
+    if [[ ! -f "$REPO_DIR/tests/conftest.py" ]]; then
+        echo "  ${BOLD}pytest-bdd Setup${RESET}"
+        echo ""
+        read -r -p "  Initialize pytest-bdd scaffolding? [Y/n]: " SCAFFOLD_CHOICE
+        SCAFFOLD_CHOICE="${SCAFFOLD_CHOICE:-Y}"
+
+        if [[ "$SCAFFOLD_CHOICE" =~ ^[Yy]$ ]]; then
+            info "Bootstrapping pytest-bdd..."
+
+            # Create directory structure
+            mkdir -p "$REPO_DIR/tests/features"
+            mkdir -p "$REPO_DIR/tests/step_defs"
+            info "Created tests/ directory structure"
+
+            # Create conftest.py with pytest-bdd scenario discovery
+            cat > "$REPO_DIR/tests/conftest.py" <<'CONFEOF'
+"""pytest-bdd conftest -- auto-discovers .feature files and provides shared fixtures."""
+import pytest
+
+
+@pytest.fixture
+def project_root(tmp_path):
+    """Provide a temporary directory for test isolation."""
+    return tmp_path
+CONFEOF
+            info "Created tests/conftest.py"
+
+            # Create requirements.txt
+            cat > "$REPO_DIR/requirements.txt" <<'REQEOF'
+pytest>=7.0
+pytest-bdd>=7.0
+httpx>=0.27
+REQEOF
+            info "Created requirements.txt"
+
+            # Install dependencies
+            (cd "$REPO_DIR" && pip install -r requirements.txt --quiet 2>/dev/null) || true
+            info "Installed pytest, pytest-bdd, httpx"
+
+            # Add Python cache dirs to .gitignore
+            GITIGNORE_ADDITIONS=""
+            if ! grep -q '^__pycache__/' "$REPO_DIR/.gitignore" 2>/dev/null; then
+                GITIGNORE_ADDITIONS+="\n# Python\n__pycache__/\n*.pyc"
+            fi
+            if ! grep -q '^\\.pytest_cache/' "$REPO_DIR/.gitignore" 2>/dev/null; then
+                GITIGNORE_ADDITIONS+="\n.pytest_cache/"
+            fi
+            if [[ -n "$GITIGNORE_ADDITIONS" ]]; then
+                echo -e "$GITIGNORE_ADDITIONS" >> "$REPO_DIR/.gitignore"
+            fi
+
+            # Commit scaffolding
+            git -C "$REPO_DIR" add -A
+            git -C "$REPO_DIR" commit --quiet -m "chore: add pytest-bdd test scaffolding"
+            info "Committed scaffolding to git"
+        else
+            info "Skipping scaffolding -- you can set it up manually later"
+        fi
+    else
+        info "tests/conftest.py already exists -- skipping scaffolding"
+    fi
+elif [[ ! -f "$REPO_DIR/playwright.config.ts" && ! -f "$REPO_DIR/cucumber.js" ]]; then
+    # --- Browser / Playwright+Cucumber bootstrap ---
     echo "  ${BOLD}Playwright + Cucumber Setup${RESET}"
     echo ""
     read -r -p "  Initialize Playwright+Cucumber scaffolding? [Y/n]: " SCAFFOLD_CHOICE
@@ -591,7 +661,8 @@ else
     info "Playwright/Cucumber config already exists -- skipping scaffolding"
 fi
 
-# ─── Phase 4c: Test data + env scripts (always created) ─────────────────────
+# ─── Phase 4c: Test data + env scripts (browser surface only) ────────────────
+if [[ "$TESTING_SURFACE" == "browser" ]]; then
 mkdir -p "$REPO_DIR/e2e/support"
 
 # Create test-data.yaml (skip if exists)
@@ -658,34 +729,48 @@ if [[ -n "$(git -C "$REPO_DIR" status --porcelain e2e/support/ 2>/dev/null)" ]];
     git -C "$REPO_DIR" add e2e/support/test-data.yaml e2e/support/env-setup.sh e2e/support/env-teardown.sh 2>/dev/null || true
     git -C "$REPO_DIR" commit --quiet -m "chore: add test data and env setup files" 2>/dev/null || true
 fi
+fi  # end TESTING_SURFACE == browser
 
 # ─── Phase 4d: Copy existing features + page objects ─────────────────────────
 if [[ "$FEATURES_MODE" == "existing" ]]; then
-    mkdir -p "$REPO_DIR/e2e/features"
-    mkdir -p "$REPO_DIR/e2e/pages/yaml-refs"
+    if [[ "$TESTING_SURFACE" == "python" ]]; then
+        FEATURES_DEST="tests/features"
+    else
+        FEATURES_DEST="e2e/features"
+    fi
+
+    mkdir -p "$REPO_DIR/$FEATURES_DEST"
+    if [[ "$TESTING_SURFACE" == "browser" ]]; then
+        mkdir -p "$REPO_DIR/e2e/pages/yaml-refs"
+    fi
 
     for src in "${FEATURE_SOURCE_PATHS[@]}"; do
         if [[ -f "$REPO_DIR/$src" ]]; then
-            cp "$REPO_DIR/$src" "$REPO_DIR/e2e/features/"
-            info "Copied $src -> e2e/features/"
+            cp "$REPO_DIR/$src" "$REPO_DIR/$FEATURES_DEST/"
+            info "Copied $src -> $FEATURES_DEST/"
         else
             warn "Feature file not found: $src"
         fi
     done
 
-    for po in "${PO_FILES[@]}"; do
-        if [[ -f "$REPO_DIR/$po" ]]; then
-            cp "$REPO_DIR/$po" "$REPO_DIR/e2e/pages/yaml-refs/"
-            info "Copied $po -> e2e/pages/yaml-refs/"
-        else
-            warn "Page object file not found: $po"
-        fi
-    done
+    if [[ "$TESTING_SURFACE" == "browser" ]]; then
+        for po in "${PO_FILES[@]}"; do
+            if [[ -f "$REPO_DIR/$po" ]]; then
+                cp "$REPO_DIR/$po" "$REPO_DIR/e2e/pages/yaml-refs/"
+                info "Copied $po -> e2e/pages/yaml-refs/"
+            else
+                warn "Page object file not found: $po"
+            fi
+        done
+    fi
 
     # Commit copied files
-    if [[ -n "$(git -C "$REPO_DIR" status --porcelain e2e/ 2>/dev/null)" ]]; then
-        git -C "$REPO_DIR" add e2e/features/ e2e/pages/yaml-refs/ 2>/dev/null || true
-        git -C "$REPO_DIR" commit --quiet -m "chore: copy existing feature files and page objects to e2e/" 2>/dev/null || true
+    if [[ -n "$(git -C "$REPO_DIR" status --porcelain "$FEATURES_DEST" 2>/dev/null)" ]]; then
+        git -C "$REPO_DIR" add "$FEATURES_DEST/" 2>/dev/null || true
+        if [[ "$TESTING_SURFACE" == "browser" ]]; then
+            git -C "$REPO_DIR" add e2e/pages/yaml-refs/ 2>/dev/null || true
+        fi
+        git -C "$REPO_DIR" commit --quiet -m "chore: copy existing feature files to $FEATURES_DEST/" 2>/dev/null || true
     fi
 fi
 
@@ -749,9 +834,10 @@ tmux:
   session_name: $PROJECT_KEY
 
 repo_dir: $REPO_DIR
+testing_surface: "$TESTING_SURFACE"
 
 ui:
-  base_url: $UI_BASE_URL
+  base_url: "${UI_BASE_URL:-}"
 
 test_credentials:
   email: "${TEST_USER_EMAIL:-}"
@@ -764,6 +850,7 @@ env_setup:
   teardown_command: "${ENV_TEARDOWN_CMD:-}"
 
 features_mode: "$FEATURES_MODE"
+$(if [[ "$TESTING_SURFACE" == "python" ]]; then echo "test_command: \"$TEST_COMMAND\""; fi)
 
 agents:
   writer:
@@ -783,6 +870,13 @@ info "Created projects/$PROJECT_KEY/config.yaml"
     echo "  \"tasks\": ["
 
     if [[ "$FEATURES_MODE" == "existing" ]]; then
+        if [[ "$TESTING_SURFACE" == "python" ]]; then
+            FEATURE_DEST_DIR="tests/features"
+            STEP_FRAMEWORK="pytest-bdd"
+        else
+            FEATURE_DEST_DIR="e2e/features"
+            STEP_FRAMEWORK="Cucumber"
+        fi
         TASK_NUM=0
         LAST_IDX=$(( ${#FEATURE_SOURCE_PATHS[@]} - 1 ))
         for i in "${!FEATURE_SOURCE_PATHS[@]}"; do
@@ -797,10 +891,10 @@ info "Created projects/$PROJECT_KEY/config.yaml"
     {
       "id": "bdd-$TASK_NUM",
       "title": "Implement step defs for $FNAME",
-      "description": "Implement Cucumber step definitions and Playwright Page Objects for existing feature file: e2e/features/$BASENAME ($SCOUNT scenarios)",
-      "feature_file": "e2e/features/$BASENAME",
+      "description": "Implement $STEP_FRAMEWORK step definitions for existing feature file: $FEATURE_DEST_DIR/$BASENAME ($SCOUNT scenarios)",
+      "feature_file": "$FEATURE_DEST_DIR/$BASENAME",
       "source_feature": "$SRC",
-      "base_url": "$UI_BASE_URL",
+      "base_url": "${UI_BASE_URL:-}",
       "scenario_count": $SCOUNT,
       "status": "pending",
       "attempts": 0,
@@ -956,28 +1050,130 @@ You have these tools from the `agent-bridge` MCP server:
 - If tests pass, report success with scenario counts
 EXECMCP
 
+# --- Python surface MCP sections ---
+IFS= read -r -d '' WRITER_MCP_SECTION_PYTHON <<'WRITERMCPPY' || true
+
+---
+
+## Communication Protocol (MCP-Based)
+
+You are the **WRITER** agent in an automated BDD testing workflow with an AI orchestrator.
+
+### MCP Tools Available
+You have these tools from the `agent-bridge` MCP server:
+
+- **`send_to_executor`** -- Notify Executor that step definitions are ready to run
+  - `summary`: What you wrote/changed
+  - `files_changed`: List of files created or modified
+  - `feature_files`: List of .feature files to test
+  - `dry_run_output`: Output from pytest --collect-only
+
+- **`check_messages`** -- Check your mailbox for orchestrator tasks and Executor feedback
+  - `role`: Always use `"writer"`
+
+- **`list_workspace`** -- See all files in the shared workspace
+
+- **`read_workspace_file`** -- Read a specific file from workspace
+
+### Workflow
+1. Receive a task via `check_messages` (role: `"writer"`)
+2. Read the .feature file to understand all scenarios and steps
+3. Create step definitions in `tests/step_defs/` using pytest-bdd decorators
+4. Add any needed fixtures in `tests/conftest.py`
+5. Validate: `pytest --collect-only`
+6. **Commit your work**: `git add . && git commit -m "feat: add step defs for <feature>"`
+7. Call `send_to_executor` with summary and files changed
+8. Wait -- periodically call `check_messages` with role `"writer"` to get feedback
+
+### Rules
+- ALWAYS commit your code BEFORE calling send_to_executor
+- Use subprocess.run() for CLI testing, direct imports for modules, httpx for APIs
+- Write clear pytest-bdd step definitions matching the Gherkin steps exactly
+- If a task is ambiguous, make reasonable assumptions and document them
+WRITERMCPPY
+
+IFS= read -r -d '' EXECUTOR_MCP_SECTION_PYTHON <<'EXECMCPPY' || true
+
+---
+
+## Communication Protocol (MCP-Based)
+
+You are the **EXECUTOR** agent in an automated BDD testing workflow with an AI orchestrator.
+
+### MCP Tools Available
+You have these tools from the `agent-bridge` MCP server:
+
+- **`send_executor_results`** -- Report test execution results
+  - `status`: `"pass"` or `"fail"`
+  - `summary`: Summary of test results
+  - `scenarios_passed`: Number of scenarios that passed
+  - `scenarios_failed`: Number of scenarios that failed
+  - `failures`: Array of failure details (scenario, step, error, traceback)
+
+- **`check_messages`** -- Check your mailbox for run requests
+  - `role`: Always use `"executor"`
+
+- **`list_workspace`** -- See all files in the shared workspace
+
+- **`read_workspace_file`** -- Read a specific file from workspace
+
+### Workflow
+1. Receive a run request via `check_messages` (role: `"executor"`)
+2. Step definitions are already in your worktree (merged by orchestrator)
+3. Run environment setup if specified
+4. Run: `pytest tests/ -v --tb=short`
+5. Run environment teardown if specified
+6. Analyze results
+7. Call `send_executor_results` with status, summary, and failure details
+
+### Rules
+- Do NOT modify feature files, step definitions, or fixtures
+- If tests fail due to test code bugs (wrong imports, bad assertions): report to Writer
+- If tests fail due to application bugs: report as application issue
+- If tests pass, report success with scenario counts
+- Provide actionable failure details so Writer can fix issues
+EXECMCPPY
+
 # Extract role prompts from BDD prompt file
-# Select Writer prompt based on features mode
-if [[ "$FEATURES_MODE" == "existing" ]]; then
-    WRITER_ROLE_PROMPT=$(extract_prompt "$PROMPT_FILE" "writer_agent_existing/CLAUDE.md")
+# Select Writer prompt based on testing_surface x features_mode
+if [[ "$TESTING_SURFACE" == "python" ]]; then
+    if [[ "$FEATURES_MODE" == "existing" ]]; then
+        WRITER_ROLE_PROMPT=$(extract_prompt "$PROMPT_FILE" "writer_agent_python_existing/CLAUDE.md")
+    else
+        WRITER_ROLE_PROMPT=$(extract_prompt "$PROMPT_FILE" "writer_agent_python/CLAUDE.md")
+    fi
+    EXECUTOR_ROLE_PROMPT=$(extract_prompt "$PROMPT_FILE" "executor_agent_python/CLAUDE.md")
 else
-    WRITER_ROLE_PROMPT=$(extract_prompt "$PROMPT_FILE" "writer_agent/CLAUDE.md")
+    if [[ "$FEATURES_MODE" == "existing" ]]; then
+        WRITER_ROLE_PROMPT=$(extract_prompt "$PROMPT_FILE" "writer_agent_existing/CLAUDE.md")
+    else
+        WRITER_ROLE_PROMPT=$(extract_prompt "$PROMPT_FILE" "writer_agent/CLAUDE.md")
+    fi
+    EXECUTOR_ROLE_PROMPT=$(extract_prompt "$PROMPT_FILE" "executor_agent/CLAUDE.md")
 fi
-EXECUTOR_ROLE_PROMPT=$(extract_prompt "$PROMPT_FILE" "executor_agent/CLAUDE.md")
+
+# Select MCP sections based on testing surface
+if [[ "$TESTING_SURFACE" == "python" ]]; then
+    ACTIVE_WRITER_MCP="$WRITER_MCP_SECTION_PYTHON"
+    ACTIVE_EXECUTOR_MCP="$EXECUTOR_MCP_SECTION_PYTHON"
+else
+    ACTIVE_WRITER_MCP="$WRITER_MCP_SECTION"
+    ACTIVE_EXECUTOR_MCP="$EXECUTOR_MCP_SECTION"
+fi
 
 # --- Writer CLAUDE.md ---
 if [[ -f "$WRITER_DIR/CLAUDE.md" ]]; then
     if grep -q "agent-bridge" "$WRITER_DIR/CLAUDE.md" 2>/dev/null; then
         info "Writer CLAUDE.md already has MCP protocol -- skipped"
     else
-        echo "$WRITER_MCP_SECTION" >> "$WRITER_DIR/CLAUDE.md"
+        echo "$ACTIVE_WRITER_MCP" >> "$WRITER_DIR/CLAUDE.md"
         success "Appended MCP protocol to existing $WRITER_DIR/CLAUDE.md"
     fi
 else
     {
         printf '%s\n\n' "# Writer Agent -- $PROJECT_NAME"
         printf '%s\n' "$WRITER_ROLE_PROMPT"
-        printf '%s\n' "$WRITER_MCP_SECTION"
+        printf '%s\n' "$ACTIVE_WRITER_MCP"
     } > "$WRITER_DIR/CLAUDE.md"
     info "Created $WRITER_DIR/CLAUDE.md"
 fi
@@ -987,14 +1183,14 @@ if [[ -f "$EXECUTOR_DIR/CLAUDE.md" ]]; then
     if grep -q "agent-bridge" "$EXECUTOR_DIR/CLAUDE.md" 2>/dev/null; then
         info "Executor CLAUDE.md already has MCP protocol -- skipped"
     else
-        echo "$EXECUTOR_MCP_SECTION" >> "$EXECUTOR_DIR/CLAUDE.md"
+        echo "$ACTIVE_EXECUTOR_MCP" >> "$EXECUTOR_DIR/CLAUDE.md"
         success "Appended MCP protocol to existing $EXECUTOR_DIR/CLAUDE.md"
     fi
 else
     {
         printf '%s\n\n' "# Executor Agent -- $PROJECT_NAME"
         printf '%s\n' "$EXECUTOR_ROLE_PROMPT"
-        printf '%s\n' "$EXECUTOR_MCP_SECTION"
+        printf '%s\n' "$ACTIVE_EXECUTOR_MCP"
     } > "$EXECUTOR_DIR/CLAUDE.md"
     info "Created $EXECUTOR_DIR/CLAUDE.md"
 fi


### PR DESCRIPTION
## Summary

- Adds `testing_surface` config field (`browser` default, `python` for pytest-bdd)
- Wizard agent asks surface first, adjusts conversation flow (skip page inspection for python, staging URL optional)
- `new-project.sh` conditionally bootstraps pytest-bdd (`tests/` dir, `conftest.py`, `requirements.txt`) or Playwright+Cucumber (`e2e/` dir)
- Orchestrator branches Writer/Executor instructions on `testing_surface` in `assign_task_to_writer()`, `handle_writer_message()`, `handle_executor_message()`
- 3 new agent prompts in `BDD PROMPTS.md`: `writer_agent_python`, `writer_agent_python_existing`, `executor_agent_python`
- Existing features copied to `tests/features/` (python) or `e2e/features/` (browser)
- Backward compatible: all existing projects default to `browser`

Closes #4

## Test plan

- [ ] `bash -n scripts/new-project.sh` -- syntax check (verified)
- [ ] `python3 -m py_compile orchestrator/orchestrator.py` -- syntax check (verified)
- [ ] All 6 FILE_TARGET sections extract correctly via `awk` (verified)
- [ ] Browser regression: wizard with browser project produces Playwright+Cucumber bootstrap unchanged
- [ ] Python surface: wizard with CLI project produces pytest-bdd scaffolding, no Playwright files
- [ ] Python + existing features: features copied to `tests/features/`, tasks reference pytest-bdd
- [ ] E2E: launch BDD pipeline with MAS v2 `.feature` files, Writer implements pytest-bdd steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)